### PR TITLE
Jupyter declarative extension requirement

### DIFF
--- a/docs/2_real_world_examples/01-accessing-data.ipynb
+++ b/docs/2_real_world_examples/01-accessing-data.ipynb
@@ -7,11 +7,10 @@
    "source": [
     "# **Accessing and Downloading Data**\n",
     "\n",
-    "```{admonition} Tutorial does not work on EO4PH Cluster\n",
+    ":::{important} Tutorial does not work on EO4PH Cluster \n",
     ":class: error\n",
-    "\n",
     "This tutorial is specific to the GEOAnalytics cluster deployed to the Google Cloud environment. This tutorial does not work on the EO4PH cluster which is deployed to Azure.\n",
-    "```\n",
+    "::::\n",
     "\n",
     "There are multiple methods of accessing data such as MODIS, VIIRS, Sentinel-2, Landsat-8, and Sentinel-1. Some data are publically available within the GEOAnalytics environment and mounted appropriately. If the data is not mounted as a bucket, it may be available through STAC endpoints within GEOAnalytics. Finally, if the data does not exist in either of those places, using a client to request data over HTTPS may be required.  \n",
     "\n",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,7 +39,6 @@ extensions = [
     "sphinx_design",
     "myst_parser",
     'IPython.sphinxext.ipython_console_highlighting',
-    "colon_fence"
 ]
 
 source_suffix = [".rst", ".md"]
@@ -51,7 +50,10 @@ nbsphinx_execute_arguments = [
     "--InlineBackend.rc={'figure.dpi': 96}",
 ]
 
-myst_enable_extensions = ["colon_fence"]
+myst_enable_extensions = [
+    "colon_fence",
+    "html_admonition",
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,7 +38,8 @@ extensions = [
     "sphinxcontrib.spelling",
     "sphinx_design",
     "myst_parser",
-    'IPython.sphinxext.ipython_console_highlighting'
+    'IPython.sphinxext.ipython_console_highlighting',
+    "colon_fence"
 ]
 
 source_suffix = [".rst", ".md"]


### PR DESCRIPTION
The MYST-Parser extensions are not being generated
- they work with Jupyter book
- tried enabling "colon_fence" and "html_admonitions" 