### PR TITLE
updating the github actions to commit cname to ghpages

### DIFF
--- a/.github/workflows/build-sphinx-docs.yaml
+++ b/.github/workflows/build-sphinx-docs.yaml
@@ -26,3 +26,9 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         branch: gh-pages
+    - name: Deploy
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./
+        cname: docs.geoanalytics.ca


### PR DESCRIPTION
The current implementation of GH-Pages removes the CNAME from the commit
Using a GitHub Action, we'll commit the CNAME to the gh-pages branch and won't have to manually enter it each deployment (which I have been doing)